### PR TITLE
Add service healthchecks, e2e connectivity check, and a webhook proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Includes:
  - Elasticsearch
  - Valkey
  - Localstack (provides DynamoDB, S3 and Cloudwatch)
+ - Squid (forward proxy for mailroom's outgoing webhook calls)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Includes:
  - Elasticsearch
  - Valkey
  - Localstack (provides DynamoDB, S3 and Cloudwatch)
- - Squid (forward proxy for mailroom's outgoing webhook calls)
+ - Squid (forward proxy for mailroom and courier outgoing calls to user-configured URLs)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > [!IMPORTANT]  
 > These example containers are for development and documentation purposes only, and are not intended for production deployments.
 
-Docker compose for public snapshot versions of RapidPro.
+Docker compose for public snapshot versions of [RapidPro](https://app.rapidpro.io).
 
 Includes:
  - RapidPro webapp and celery worker ([License](https://github.com/nyaruka/rapidpro/blob/main/LICENSE))

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Includes:
  - RapidPro webapp and celery worker ([License](https://github.com/nyaruka/rapidpro/blob/main/LICENSE))
  - Mailroom ([License](https://github.com/nyaruka/mailroom/blob/main/LICENSE))
  - Courier ([License](https://github.com/nyaruka/courier/blob/main/LICENSE))
- - Indexer ([License](https://github.com/nyaruka/rp-indexer/blob/main/LICENSE))
+ - Archiver ([License](https://github.com/nyaruka/archiver/blob/main/LICENSE))
  - nginx
  - PostgreSQL
  - Elasticsearch

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > [!IMPORTANT]  
 > These example containers are for development and documentation purposes only, and are not intended for production deployments.
 
-Docker compose for stable release versions of RapidPro.
+Docker compose for public snapshot versions of RapidPro.
 
 Includes:
  - RapidPro webapp and celery worker ([License](https://github.com/nyaruka/rapidpro/blob/main/LICENSE))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       timeout: 5s
 
   valkey:
-    image: valkey/valkey:8.0-alpine
+    image: valkey/valkey:8.1-alpine
     command: valkey-server --save 60 1 --loglevel warning
     volumes:
       - valkey:/data
@@ -66,6 +66,16 @@ services:
       test: ["CMD-SHELL", "curl -s http://localhost:4566/_localstack/health >/dev/null || exit 1"]
       interval: 10s
       timeout: 5s
+
+  squid:
+    build:
+      context: ./squid/
+    ports:
+      - 3128:3128
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 3128 || exit 1"]
+      interval: 5s
+      timeout: 2s
 
   rapidpro:
     image: nyaruka/rapidpro:stable
@@ -117,6 +127,8 @@ services:
     depends_on:
       rapidpro:
         condition: service_healthy
+      squid:
+        condition: service_healthy
     ports:
       - 8090:8090
       - 8091:8091
@@ -129,6 +141,7 @@ services:
       MAILROOM_DOMAIN: ${MAILROOM_DOMAIN:-host.docker.internal}
       MAILROOM_ATTACHMENT_DOMAIN: ${MAILROOM_ATTACHMENT_DOMAIN:-host.docker.internal}
       MAILROOM_DISALLOWED_NETWORKS: 6.6.6.6
+      MAILROOM_WEBHOOK_PROXY_URL: http://squid:3128
       MAILROOM_AUTH_TOKEN: topsecret
       MAILROOM_COURIER_ENDPOINT: http://courier:8081
       MAILROOM_COURIER_AUTH_TOKEN: topsecret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,8 @@ services:
     depends_on:
       rapidpro:
         condition: service_healthy
+      squid:
+        condition: service_healthy
     ports:
       - 8080:8080
       - 8081:8081
@@ -179,6 +181,7 @@ services:
       COURIER_VALKEY: valkey://valkey:6379/15
       COURIER_DOMAIN: ${COURIER_DOMAIN:-host.docker.internal}
       COURIER_DISALLOWED_NETWORKS: 6.6.6.6
+      COURIER_SEND_PROXY_URL: http://squid:3128
       COURIER_AUTH_TOKEN: topsecret
       COURIER_AWS_ACCESS_KEY_ID: root
       COURIER_AWS_SECRET_ACCESS_KEY: tembatemba

--- a/squid/Dockerfile
+++ b/squid/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache squid \
+    && mkdir -p /var/log/squid /var/spool/squid \
+    && chown -R squid:squid /var/log/squid /var/spool/squid
+
+COPY squid.conf /etc/squid/squid.conf
+
+USER squid
+
+EXPOSE 3128
+
+# -N: foreground (required for containers)
+# -d 1: log to stderr at debug level 1 so startup errors are visible
+# -f: explicit config path
+CMD ["squid", "-N", "-d", "1", "-f", "/etc/squid/squid.conf"]

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -1,0 +1,51 @@
+# Outbound forward proxy for user-controlled webhook calls made by mailroom.
+# Routing webhooks through a dedicated proxy lets the network boundary, rather
+# than the application, decide where outbound requests are allowed to go.
+
+http_port 3128
+
+# Container has no resolvable hostname; silence the startup warning.
+visible_hostname squid
+
+# No pidfile — /var/run isn't writable as the non-root squid user and a
+# pidfile is pointless inside a container.
+pid_filename none
+
+# Standard ports
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl Safe_ports port 1025-65535
+acl CONNECT method CONNECT
+
+# Defense-in-depth: deny requests aimed at private, link-local or loopback
+# addresses so a webhook can't be pointed back at internal services (SSRF).
+acl to_private dst 10.0.0.0/8
+acl to_private dst 172.16.0.0/12
+acl to_private dst 192.168.0.0/16
+acl to_private dst 169.254.0.0/16
+
+http_access deny to_private
+http_access deny to_localhost
+http_access deny !Safe_ports
+http_access allow all
+
+# No caching: webhook responses must never be cached.
+cache deny all
+
+# Log to stdout/stderr so the container log driver picks them up.
+access_log stdio:/dev/stdout combined
+cache_log  stdio:/dev/stderr
+logfile_rotate 0
+
+# Don't reveal the proxy to upstream servers.
+forwarded_for delete
+via off
+
+# Timeouts tuned for user webhooks.
+request_timeout 60 seconds
+connect_timeout 30 seconds
+
+# Squid resolves upstream hostnames itself.
+positive_dns_ttl 30 minutes
+negative_dns_ttl 1 minute


### PR DESCRIPTION
## What

- **Service healthchecks** for mailroom and courier. Each daemon runs a public and an internal listener; the healthcheck probes *both* ports (mailroom 8090/8091, courier 8080/8081) so a container is only "healthy" once both are actually serving.
- **CI waits on real readiness.** `docker compose up -d` now uses `--wait --wait-timeout 300`, so CI blocks until every service reports healthy instead of relying on a retry loop in the test.
- **End-to-end mailroom connectivity check** added to the e2e test, exercising the full contact-search path through mailroom (and the retry loop around it dropped now that startup is health-gated).
- **Forward proxy for webhooks.** New `squid` service that mailroom routes user-controlled webhook calls through (`MAILROOM_WEBHOOK_PROXY_URL`), so the network boundary rather than the app decides where outbound requests may go. The proxy denies private/link-local/loopback destinations as SSRF defense-in-depth.
- **Valkey bumped** from 8.0 to 8.1.

## Why

The previous setup let CI start before services were genuinely ready and leaned on a test-side retry loop to paper over it, which was flaky. Gating on healthchecks (that check both listeners) makes startup deterministic. The squid proxy mirrors how outbound webhooks are expected to be funneled through a controlled egress point.

## Reviewer notes

- The healthcheck `test` commands intentionally hit `/` on both the public and internal ports — both serve health there.
- The squid config (`squid/squid.conf`) is a minimal forward proxy: no caching, denies RFC1918 / `169.254/16` / loopback, logs to stdout/stderr. Verified locally that external requests proxy through (200) and private ranges are refused (403).
- These are example/dev containers (see the note in the README), not a production deployment.